### PR TITLE
Add device name and locked properties

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,7 +37,9 @@ module.exports = {
         project: ['./tsconfig.test.json'],
       },
       rules: {
+        '@typescript-eslint/no-empty-function': 'off',
         '@typescript-eslint/no-explicit-any': 'off',
+        '@typescript-eslint/no-unused-vars': 'off',
       },
     },
   ],

--- a/src/device.ts
+++ b/src/device.ts
@@ -13,6 +13,8 @@ export default class Device {
     public readonly host: RemoteInfo,
     public readonly mac: number[],
     public readonly deviceType: number = 0x272a,
+    public readonly name: string = '',
+    public readonly isLocked: boolean = false,
     public readonly model: string = '',
     public readonly manufacturer: string = '',
   ) {

--- a/src/device.ts
+++ b/src/device.ts
@@ -13,10 +13,10 @@ export default class Device {
     public readonly host: RemoteInfo,
     public readonly mac: number[],
     public readonly deviceType: number = 0x272a,
-    public readonly name: string = '',
-    public readonly isLocked: boolean = false,
     public readonly model: string = '',
     public readonly manufacturer: string = '',
+    public readonly name: string = '',
+    public readonly isLocked: boolean = false,
   ) {
     this.id = [0, 0, 0, 0];
     this.key = [0x09, 0x76, 0x28, 0x34, 0x3f, 0xe9, 0x9e, 0x23, 0x76, 0x5c, 0x15, 0x13, 0xac, 0xcf, 0x8b, 0x02];

--- a/src/index.ts
+++ b/src/index.ts
@@ -231,14 +231,14 @@ export function genDevice(
   deviceType: number,
   host: RemoteInfo,
   mac: number[],
-  name: string,
-  isLocked: boolean,
+  name?: string,
+  isLocked?: boolean,
 ): Device {
   if (deviceType in SUPPORTED_TYPES) {
-    const [DeviceClazz, ...args] = SUPPORTED_TYPES[deviceType];
-    return new DeviceClazz(host, mac, deviceType, name, isLocked, ...args);
+    const [DeviceClazz, model, manufacturer] = SUPPORTED_TYPES[deviceType];
+    return new DeviceClazz(host, mac, deviceType, model, manufacturer, name, isLocked);
   }
-  return new Device(host, mac, deviceType, name, isLocked);
+  return new Device(host, mac, deviceType, undefined, undefined, name, isLocked);
 }
 
 export function discover(timeout = 500, interfaces?: NetworkInterface, discoverIpPort = 80): Promise<Device[]> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,15 +26,7 @@ interface NetworkInterfaceModel {
 
 type NetworkInterface = NetworkInterfaceModel | NetworkInterfaceModel[];
 
-const SUPPORTED_TYPES: Record<
-  number,
-  [
-    {
-      new (host: RemoteInfo, mac: number[], deviceType?: number, model?: string, manufacturer?: string): Device;
-    },
-    ...string[],
-  ]
-> = {
+const SUPPORTED_TYPES: Record<number, [typeof Device, string, string]> = {
   0x0000: [Sp1, 'SP1', 'Broadlink'],
   0x2717: [Sp2, 'NEO', 'Ankuoo'],
   0x2719: [Sp2, 'SP2-compatible', 'Honeywell'],
@@ -235,12 +227,18 @@ export function setup(
   });
 }
 
-export function genDevice(deviceType: number, host: RemoteInfo, mac: number[]): Device {
+export function genDevice(
+  deviceType: number,
+  host: RemoteInfo,
+  mac: number[],
+  name: string,
+  isLocked: boolean,
+): Device {
   if (deviceType in SUPPORTED_TYPES) {
     const [DeviceClazz, ...args] = SUPPORTED_TYPES[deviceType];
-    return new DeviceClazz(host, mac, deviceType, ...args);
+    return new DeviceClazz(host, mac, deviceType, name, isLocked, ...args);
   }
-  return new Device(host, mac, deviceType);
+  return new Device(host, mac, deviceType, name, isLocked);
 }
 
 export function discover(timeout = 500, interfaces?: NetworkInterface, discoverIpPort = 80): Promise<Device[]> {
@@ -297,7 +295,11 @@ export function discover(timeout = 500, interfaces?: NetworkInterface, discoverI
         const deviceType = msg[0x34] | (msg[0x35] << 8);
         const mac = [...msg.subarray(0x3a, 0x40)].reverse();
         if (!devices.some((device) => device.mac.toString() === mac.toString())) {
-          devices.push(genDevice(deviceType, rinfo, mac));
+          const nameSlice = msg.slice(0x40, 0x7e);
+          const name = nameSlice.slice(0, nameSlice.indexOf(0x00)).toString('utf8');
+          const isLocked = !!msg[0x7f];
+
+          devices.push(genDevice(deviceType, rinfo, mac, name, isLocked));
         }
       });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,6 @@
-import { RemoteInfo } from 'dgram';
+import { RemoteInfo, Socket } from 'dgram';
 import Device from '../src/device';
+import * as index from '../src';
 import SpyInstance = jest.SpyInstance;
 
 export const create = <T>(clazz: { new (host: RemoteInfo, mac: number[]): T }): T =>
@@ -19,4 +20,53 @@ export const spySendPacket = (device: Device): SpyInstance => {
   return spy;
 };
 
-test.todo('');
+jest.mock('../src', (): typeof index => ({
+  ...jest.requireActual('../src'),
+  getNetworkInterfaces: () => [{ address: '192.0.2.42', broadcastAddress: '192.0.2.42' }],
+}));
+
+jest.mock('dgram', () => ({
+  createSocket: (): Socket => {
+    /* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function */
+    const socket = {
+      bind: () => socket,
+      once: (_, __) => {},
+      setBroadcast: (_) => {},
+      send: (_) => {},
+      close: () => {},
+      on(event, callback) {
+        if (event === 'message') {
+          callback(
+            Buffer.from(
+              '0000000000000000000000007b0027061605050b00000000c0a86c2c10a10000d3a20000000007000000000000000000308875207975776ca8c042902db7df24546573742d4465766963652d5350342d4e616d653100000000000000000000000000000000000000000000000000000000000000000000000000000000000200',
+              'hex',
+            ),
+            {
+              address: '192.168.108.101',
+              family: 'IPv4',
+              port: 80,
+              size: 128,
+            },
+          );
+        }
+      },
+    } as Socket;
+    /* eslint-enable @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function */
+
+    return socket;
+  },
+}));
+
+describe('index', () => {
+  describe('discover', () => {
+    it('finds correct device', async () => {
+      expect(await index.discover()).toEqual([
+        expect.objectContaining({
+          TYPE: 'SP4',
+          isLocked: false,
+          name: 'Test-Device-SP4-Name1',
+        }),
+      ]);
+    });
+  });
+});

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -27,7 +27,6 @@ jest.mock('../src', (): typeof index => ({
 
 jest.mock('dgram', () => ({
   createSocket: (): Socket => {
-    /* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function */
     const socket = {
       bind: () => socket,
       once: (_, __) => {},
@@ -51,7 +50,6 @@ jest.mock('dgram', () => ({
         }
       },
     } as Socket;
-    /* eslint-enable @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function */
 
     return socket;
   },


### PR DESCRIPTION
Thanks for this library! I was also looking for the device names, so this PR adds the device name and locked properties to `Device`. It also simplifies the type of `SUPPORTED_TYPES` so that the type signature doesn't have to be changed every time the constructor changes (like in this PR).